### PR TITLE
Adapt to conda environments on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open(os.path.join(current_dir, "README.md")) as fp:
 
 setup(
     name="python-localvenv-kernel",
-    version="0.1.6",
+    version="0.1.6+dev",
     author="Michael H. Goerz",
     author_email="mail@michaelgoerz.net",
     url="https://github.com/goerz/python-localvenv-kernel",

--- a/src/localvenv_kernel/__main__.py
+++ b/src/localvenv_kernel/__main__.py
@@ -55,6 +55,15 @@ def main():
             environment {venv_folder}
             """
         )
+    except OSError as exc_info:
+        error(
+            f"""
+            {' '.join([str(a) for a in cmd_check_kernel])}
+            failed:
+
+            ERROR: {exc_info}
+            """
+        )
     cmd = [
         python,
         "-m",
@@ -138,7 +147,11 @@ def find_python(venv):
     else:
         python = venv / "bin" / "python"
         if platform.system() == "Windows":
-            python = venv / "Scripts" / "python"
+            python = venv / "Scripts" / "python.exe"  # python -m venv
+            if not python.is_file():  # some versions of conda (?)
+                python = venv / "python.exe"
+    if not python.is_file():
+        print(f"WARNING: file '{python}' does not exist")
     return python
 
 


### PR DESCRIPTION
Some `.venv` folders created by some version of `conda` seem to put the python executable as `.venv\python.exe`